### PR TITLE
Added new Enum cases for MicroProfile support, includes Testcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ An implementation of [JSON Web Token](https://tools.ietf.org/html/rfc7519) using
 
 For more information on JSON Web Tokens, their use cases and how they work, we recommend visiting [jwt.io](https://jwt.io/introduction/). 
 
-**Reminder:** JWTs do **not** encrypt data, so never send anything sensitive or confidential in a JWT.
+
+
+**Reminder:** JWTs sent as JWS do **not** encrypt data, so never send anything sensitive or confidential in a JWT. This library does not currently support JWE.
 
 ## Table of Contents
 * [Prerequisites](#prerequisites)
@@ -157,6 +159,11 @@ if validationResult != .success {
   print("Claims validation failed: ", validationResult)
 }
 ```
+
+## MicroProfile Support
+
+This library supports MicroProfile by allowing the creation of JWTs with specific claims needed by MicroProfile. These claims are found [here](http://microprofile.io/project/eclipse/microprofile-jwt-auth/spec/src/main/asciidoc/interoperability.asciidoc). For full compliance, ensure your application saves the JWT with the name `MP-JWT` and uses `.alg["rs256"]` for token signing.
+
 
 
 ## License

--- a/Sources/SwiftJWT/Claims.swift
+++ b/Sources/SwiftJWT/Claims.swift
@@ -138,7 +138,7 @@ public enum ClaimKeys: String {
     /// Given name(s) or first name(s) (OpenID)
     case given_name
     
-    /// The token subject’s group memberships that will be mapped to Java EE style application level roles in the MicroProfile service container
+    /// The token subject’s group memberships that will be mapped to Java EE style application level roles in the MicroProfile service container (MicroProfile)
     case groups
 
     /// Issued At - standard JWT claim
@@ -150,9 +150,6 @@ public enum ClaimKeys: String {
     /// JWT ID - standard JWT claim
     case jti
     
-    /// Hint at which key was used to secure the JWT
-    case kid
-
     /// Locale (OpenID)
     case locale
 
@@ -210,7 +207,7 @@ public enum ClaimKeys: String {
     /// Time the information was last updated (OpenID)
     case updated_at
     
-    /// A human readable claim that uniquely identifies the subject or user principal of the token, across the MicroProfile services the token will be accessed with
+    /// A human readable claim that uniquely identifies the subject or user principal of the token, across the MicroProfile services the token will be accessed with (MicroProfile)
     case upn
     
     /// Web page or blog URL (OpenID)

--- a/Sources/SwiftJWT/Claims.swift
+++ b/Sources/SwiftJWT/Claims.swift
@@ -88,6 +88,7 @@ public struct Claims {
 /// Standard JWT claims are described in [RFC7519](https://tools.ietf.org/html/rfc7519#section-4.1).
 /// OpenID related claims are decsribed in [OpenID specs](http://openid.net/specs/openid-connect-core-1_0.html).
 /// SIP related claims are listed in [RFC3261](https://tools.ietf.org/html/rfc3261).
+/// MicroProfile claims are listed in [MicroProfile specs](http://microprofile.io/project/eclipse/microprofile-jwt-auth/spec/src/main/asciidoc/interoperability.asciidoc).
 /// Other claims are supported using a String as the key.
 public enum ClaimKeys: String {
     /// Authentication Context Class Reference (OpenID)

--- a/Sources/SwiftJWT/Claims.swift
+++ b/Sources/SwiftJWT/Claims.swift
@@ -137,6 +137,9 @@ public enum ClaimKeys: String {
 
     /// Given name(s) or first name(s) (OpenID)
     case given_name
+    
+    /// The token subject’s group memberships that will be mapped to Java EE style application level roles in the MicroProfile service container
+    case groups
 
     /// Issued At - standard JWT claim
     case iat
@@ -146,6 +149,9 @@ public enum ClaimKeys: String {
 
     /// JWT ID - standard JWT claim
     case jti
+    
+    /// Hint at which key was used to secure the JWT
+    case kid
 
     /// Locale (OpenID)
     case locale
@@ -203,6 +209,9 @@ public enum ClaimKeys: String {
     
     /// Time the information was last updated (OpenID)
     case updated_at
+    
+    /// A human readable claim that uniquely identifies the subject or user principal of the token, across the MicroProfile services the token will be accessed with
+    case upn
     
     /// Web page or blog URL (OpenID)
     case website

--- a/Sources/SwiftJWT/JWT.swift
+++ b/Sources/SwiftJWT/JWT.swift
@@ -123,10 +123,6 @@ public struct JWT {
         }
         return JWT(header: header, claims: claims)
     }
-    
-    public static func checkValidMicroProfile(_ jwt: JWT) throws -> Bool {
-        return true
-    }
 
     /// Validate the JWT claims. Various claims are validated if they are present in the `Claims` object.
     /// Various validations require an input. In these cases, if the claim in question exists and the input

--- a/Sources/SwiftJWT/JWT.swift
+++ b/Sources/SwiftJWT/JWT.swift
@@ -123,6 +123,10 @@ public struct JWT {
         }
         return JWT(header: header, claims: claims)
     }
+    
+    public static func checkValidMicroProfile(_ jwt: JWT) throws -> Bool {
+        return true
+    }
 
     /// Validate the JWT claims. Various claims are validated if they are present in the `Claims` object.
     /// Various validations require an input. In these cases, if the claim in question exists and the input

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -38,6 +38,7 @@ class TestJWT: XCTestCase {
             ("testSignAndVerify", testSignAndVerify),
             ("testJWT", testJWT),
             ("testSupported", testSupported),
+            ("testMicroProfile", testMicroProfile)
         ]
     }
     
@@ -110,15 +111,43 @@ class TestJWT: XCTestCase {
     }
     
     func check(jwt: JWT, algorithm: String) {
-        XCTAssertEqual(jwt.header.headers.count, 1, "Wrong number of header fields")
-        XCTAssertEqual(jwt.claims.claims.count, 6, "Wrong number of claims")
+        
+        if jwt.header[.kid] != nil {
+            
+            XCTAssertEqual(jwt.header.headers.count, 3, "Wrong number of header fields")
+            XCTAssertEqual(jwt.claims.claims.count, 7, "Wrong number of claims")
+            
+            XCTAssertEqual(jwt.header[.alg] as! String, algorithm, "Wrong .alg in decoded")
+            XCTAssertEqual(jwt.header[.kid] as! String, "abc-1234567890", "Wrong .iat in decoded")
+            XCTAssertEqual(jwt.claims[.iss] as! String, "https://server.example.com", "Wrong .iss in decoded")
+            XCTAssertEqual(jwt.claims[.exp] as! String, "2485949565.58463", "Wrong .exp in decoded")
+            XCTAssertEqual(jwt.claims[.iat] as! String, "1485949565.58463", "Wrong .iat in decoded")
+            XCTAssertEqual(jwt.claims[.upn] as! String, "jdoe@server.example.com", "Wrong .upn in decoded")
+            let arrayString = """
+            ["red-group", "green-group", "admin-group", "admin"]
+            """
+            XCTAssertEqual(jwt.claims[.groups] as! String, arrayString, "Wrong .group in decoded")
 
-        XCTAssertEqual(jwt.header[.alg] as! String, algorithm, "Wrong .alg in decoded")
-        XCTAssertEqual(jwt.claims[.iss] as! String, "issuer", "Wrong .iss in decoded")
-        XCTAssertEqual(jwt.claims[.aud] as! [String], ["clientID"], "Wrong .aud in decoded")
-        XCTAssertEqual(jwt.claims[.exp] as! String, "2485949565.58463", "Wrong .exp in decoded")
-        XCTAssertEqual(jwt.claims[.iat] as! String, "1485949565.58463", "Wrong .iat in decoded")
-        XCTAssertEqual(jwt.claims[.nbf] as! String, "1485949565.58463", "Wrong .nbf in decoded")
+            
+        } else {
+        
+            XCTAssertEqual(jwt.header.headers.count, 1, "Wrong number of header fields")
+            XCTAssertEqual(jwt.claims.claims.count, 6, "Wrong number of claims")
+
+            XCTAssertEqual(jwt.header[.alg] as! String, algorithm, "Wrong .alg in decoded")
+            XCTAssertEqual(jwt.claims[.iss] as! String, "issuer", "Wrong .iss in decoded")
+            XCTAssertEqual(jwt.claims[.exp] as! String, "2485949565.58463", "Wrong .exp in decoded")
+            XCTAssertEqual(jwt.claims[.iat] as! String, "1485949565.58463", "Wrong .iat in decoded")
+            
+            if let optionalNBF = jwt.claims[.nbf] {
+                XCTAssertEqual(optionalNBF as! String, "1485949565.58463", "Wrong .nbf in decoded")
+            }
+            
+            if let optionalAudience = jwt.claims[.aud] {
+                XCTAssertEqual(optionalAudience as! [String], ["clientID"], "Wrong .aud in decoded")
+            }
+        }
+        
     }
     
     // From jwt.io
@@ -163,6 +192,79 @@ class TestJWT: XCTestCase {
         
         algorithm = Algorithm.for(name: "HMAC512", key: rsaPrivateKey, keyType: .privateKey)
         XCTAssertNil(algorithm, "Create Algorithm for unsupported")
+    }
+    
+    func testMicroProfile() {
+        
+        // Make a JWT according to http://microprofile.io/project/eclipse/microprofile-jwt-auth/spec/src/main/asciidoc/interoperability.asciidoc
+        var jwt = JWT(header: Header([.alg:"rs256", .typ:"JWT", .kid:"abc-1234567890"]), claims: Claims([.iss:"https://server.example.com", .jti:"a-123", .iat:"1485949565.58463", .exp:"2485949565.58463", .sub:"2400320", .upn:"jdoe@server.example.com", .groups:
+            """
+            ["red-group", "green-group", "admin-group", "admin"]
+            """
+            ]))
+        
+        
+        do {
+            // encode
+            if let encoded = try jwt.encode() {
+                if let decoded = try JWT.decode(encoded) {
+                    check(jwt: decoded, algorithm: "none")
+                    
+                    XCTAssertEqual(decoded.validateClaims(issuer: "https://server.example.com"), .success, "Validation failed")
+                }
+                else {
+                    XCTFail("Failed to decode")
+                }
+            }
+            else {
+                XCTFail("Failed to encode")
+            }
+            
+            // public key
+            if let signed = try jwt.sign(using: .rs256(rsaPrivateKey, .privateKey)) {
+                let ok = try JWT.verify(signed, using: .rs256(rsaPublicKey, .publicKey))
+                XCTAssertTrue(ok, "Verification failed")
+                
+                if let decoded = try JWT.decode(signed) {
+                    check(jwt: decoded, algorithm: "RS256")
+                    
+                    XCTAssertEqual(decoded.validateClaims(issuer: "https://server.example.com"), .success, "Validation failed")
+                }
+                else {
+                    XCTFail("Failed to decode")
+                }
+            }
+            else {
+                XCTFail("Failed to sign")
+            }
+            
+            // certificate
+            if let signed = try jwt.sign(using: .rs256(certPrivateKey, .privateKey)) {
+                let ok = try JWT.verify(signed, using: .rs256(certificate, .certificate))
+                XCTAssertTrue(ok, "Verification failed")
+                
+                if let decoded = try JWT.decode(signed) {
+                    check(jwt: decoded, algorithm: "RS256")
+                    
+                    XCTAssertEqual(decoded.validateClaims(issuer: "https://server.example.com"), .success, "Validation failed")
+                }
+                else {
+                    XCTFail("Failed to decode")
+                }
+            }
+            else {
+                XCTFail("Failed to sign")
+            }
+            
+        }
+        catch {
+            XCTFail("Failed to sign, verify or decode")
+        }
+        
+
+        
+        
+        
     }
 
 }


### PR DESCRIPTION
Added a bunch of Claim Types for MicroProfile support including their descriptions as per http://microprofile.io/project/eclipse/microprofile-jwt-auth/spec/src/main/asciidoc/interoperability.asciidoc. Also added a new test case for generating a JWT with these specs.

Added a small section to the README hinting at best practice for making a MP-JWT and improved the JWS vs JWE explanation.