### PR TITLE
Add support for HMAC signing and verifying

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,11 +29,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/BlueRSA.git", from:"1.0.0"),
+        .package(url: "https://github.com/IBM-Swift/BlueCryptor.git", from:"1.0.0"),
         .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", from: "1.7.0"),
         .package(url: "https://github.com/IBM-Swift/KituraContracts.git", from: "1.1.0")
     ],
     targets: [
-        .target(name: "SwiftJWT", dependencies: ["CryptorRSA", "LoggerAPI", "KituraContracts"]),
+        .target(name: "SwiftJWT", dependencies: ["CryptorRSA", "LoggerAPI", "KituraContracts", "Cryptor"]),
         .testTarget(name: "SwiftJWTTests", dependencies: ["SwiftJWT"])
 	]
 )

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ The supported algorithms for signing and verifying JWTs are:
 * RS256 - RSASSA-PKCS1-v1_5 using SHA-256
 * RS384 - RSASSA-PKCS1-v1_5 using SHA-384
 * RS512 - RSASSA-PKCS1-v1_5 using SHA-512
+* HS256 - HMAC using using SHA-256
+* HS384 - HMAC using using SHA-384
+* HS512 - HMAC using using SHA-512
 * none - Don't sign or verify the JWT
 
 ### Validate claims

--- a/Sources/SwiftJWT/BlueHMAC.swift
+++ b/Sources/SwiftJWT/BlueHMAC.swift
@@ -1,0 +1,81 @@
+/**
+ * Copyright IBM Corporation 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Cryptor
+import LoggerAPI
+import Foundation
+
+class BlueHMAC: SignerAlgorithm, VerifierAlgorithm {
+    let name: String = "HMAC"
+    
+    private let key: Data
+    private let algorithm: HMAC.Algorithm
+    
+    init(key: Data, algorithm: HMAC.Algorithm) {
+        self.key = key
+        self.algorithm = algorithm
+    }
+    
+    func sign(header: String, claims: String) throws -> String {
+        let unsignedJWT = header + "." + claims
+        guard let unsignedData = unsignedJWT.data(using: .utf8) else {
+            throw JWTError.invalidJWTString
+        }
+        let signature = try sign(unsignedData)
+        let signatureString = signature.base64urlEncodedString()
+        return header + "." + claims + "." + signatureString
+    }
+    
+    func sign(_ data: Data) throws -> Data {
+        guard #available(macOS 10.12, iOS 10.0, *) else {
+            Log.error("macOS 10.12.0 (Sierra) or higher or iOS 10.0 or higher is required by Cryptor")
+            throw JWTError.osVersionToLow
+        }
+        guard let hmac = HMAC(using: algorithm, key: key).update(data: data)?.final() else {
+            throw JWTError.invalidPrivateKey
+        }
+        return Data(bytes: hmac)
+    }
+    
+    
+    func verify(jwt: String) -> Bool {
+        let components = jwt.components(separatedBy: ".")
+        if components.count == 3 {
+            guard let signature = Data(base64urlEncoded: components[2]),
+                let jwtData = (components[0] + "." + components[1]).data(using: .utf8)
+                else {
+                    return false
+            }
+            return self.verify(signature: signature, for: jwtData)
+        } else {
+            return false
+        }
+    }
+    
+    func verify(signature: Data, for data: Data) -> Bool {
+        guard #available(macOS 10.12, iOS 10.0, *) else {
+            return false
+        }
+        do {
+            let expectedHMAC = try sign(data)
+            return expectedHMAC == signature
+        }
+        catch {
+            Log.error("Verification failed: \(error)")
+            return false
+        }
+    }
+}

--- a/Sources/SwiftJWT/JWTSigner.swift
+++ b/Sources/SwiftJWT/JWTSigner.swift
@@ -63,6 +63,21 @@ public struct JWTSigner {
         return JWTSigner(name: "RS512", signerAlgorithm: BlueRSA(key: privateKey, keyType: .privateKey, algorithm: .sha512))
     }
     
+    /// Initialize a JWTSigner using the HMAC 256 bits algorithm and the provided privateKey.
+    public static func hs256(key: Data) -> JWTSigner {
+        return JWTSigner(name: "HS256", signerAlgorithm: BlueHMAC(key: key, algorithm: .sha256))
+    }
+    
+    /// Initialize a JWTSigner using the HMAC 384 bits algorithm and the provided privateKey.
+    public static func hs384(key: Data) -> JWTSigner {
+        return JWTSigner(name: "HS384", signerAlgorithm: BlueHMAC(key: key, algorithm: .sha384))
+    }
+    
+    /// Initialize a JWTSigner using the HMAC 512 bits algorithm and the provided privateKey.
+    public static func hs512(key: Data) -> JWTSigner {
+        return JWTSigner(name: "HS512", signerAlgorithm: BlueHMAC(key: key, algorithm: .sha512))
+    }
+    
     /// Initialize a JWTSigner that will not sign the JWT. This is equivelent to using the "none" alg header.
     public static let none = JWTSigner(name: "none", signerAlgorithm: NoneAlgorithm())
 }

--- a/Sources/SwiftJWT/JWTVerifier.swift
+++ b/Sources/SwiftJWT/JWTVerifier.swift
@@ -75,6 +75,21 @@ public struct JWTVerifier {
         return JWTVerifier(verifierAlgorithm: BlueRSA(key: certificate, keyType: .certificate, algorithm: .sha512))
     }
     
+    /// Initialize a JWTSigner using the HMAC 256 bits algorithm and the provided privateKey.
+    public static func hs256(key: Data) -> JWTVerifier {
+        return JWTVerifier(verifierAlgorithm: BlueHMAC(key: key, algorithm: .sha256))
+    }
+    
+    /// Initialize a JWTSigner using the HMAC 384 bits algorithm and the provided privateKey.
+    public static func hs384(key: Data) -> JWTVerifier {
+        return JWTVerifier(verifierAlgorithm: BlueHMAC(key: key, algorithm: .sha384))
+    }
+    
+    /// Initialize a JWTSigner using the HMAC 512 bits algorithm and the provided privateKey.
+    public static func hs512(key: Data) -> JWTVerifier {
+        return JWTVerifier(verifierAlgorithm: BlueHMAC(key: key, algorithm: .sha512))
+    }
+    
     /// Initialize a JWTVerifier that will always return true when verifying the JWT. This is equivelent to using the "none" alg header.
     public static let none = JWTVerifier(verifierAlgorithm: NoneAlgorithm())
 }

--- a/SwiftJWT.podspec
+++ b/SwiftJWT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftJWT"
-  s.version      = "3.0.0"
+  s.version      = "3.1.0"
   s.summary      = "An implementation of JSON Web Token using Swift."
   s.homepage     = "https://github.com/IBM-Swift/Swift-JWT"
   s.license      = { :type => "Apache License, Version 2.0" }

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -28,7 +28,7 @@ let certPrivateKey = read(fileName: "cert_private_key")
 let certificate = read(fileName: "certificate")
 let rsaEncodedTestClaimJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwic3ViIjoiMTIzNDU2Nzg5MCJ9.WJHaxAjhLu7wkw2J3B7ZpW-pnX-WEDJuy7l46nHZRWtZrH_4f8724v-4V48UlHtEgQpUXCHyGRyWPgPJCdGIfy2vD5GBoMJ1kdNWQa0UVOajTk0omUIloBPKgo-45m3w15ub-_4bihyZOI8dCK9zk5vjvUGnzdKartNi9AN5kNM"
 let certificateEncodedTestClaimJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwic3ViIjoiMTIzNDU2Nzg5MCJ9.CpnzQLuWGfH5Kba36vg0ZZKBnzwlrIgapFVfBfk_nea-eej84ktHZANqIeolskZopRJ4DQ3oaLtHWEg16-ZsujxmkOdiAIbk0-C4QLOVFLZH78WLZAqkyNLS8rFuK9hloLNwz1j6VVUd1f0SOT-wIRzL0_0VRYqQd1bVcCj7wc7BmXENlOfHY7KGHS-6JX-EClT1DygDSoCmdvBExBf3vx0lwMIbP4ryKkyhOoU13ZfSUt1gpP9nZAfzqfRTPxZc_f7neiAlMlF6SzsedsskRCNegW8cg5e_NuVmZZkj0_bnswXFDMmIaxiPdtOEWkmyEOca-EHSwbO5PgCgXOIrgg"
-// encoded using "Super Secret Key"
+// A `TestClaims` encoded using HMAC with "Super Secret Key" from "www.jwt.io"
 let hmacEncodedTestClaimJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwic3ViIjoiMTIzNDU2Nzg5MCJ9.8kIE0ZCq1Vw7aW1kACpgJLcgY2DpTXgO6P5T3cdCuTs"
 let jwtSigners: [String: JWTSigner] = ["0": .rs256(privateKey: rsaPrivateKey), "1": .rs256(privateKey: certPrivateKey)]
 let jwtVerifiers: [String: JWTVerifier] = ["0": .rs256(publicKey: rsaPublicKey), "1": .rs256(certificate: certificate)]

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -19,6 +19,7 @@ import Foundation
 
 @testable import SwiftJWT
 
+let hmacKey = "Super Secret Key"
 let rsaPrivateKey = read(fileName: "rsa_private_key")
 let rsaPublicKey = read(fileName: "rsa_public_key")
 let rsaJWTEncoder = JWTEncoder(jwtSigner: .rs256(privateKey: rsaPrivateKey))
@@ -160,6 +161,25 @@ class TestJWT: XCTestCase {
             if let decoded = try? JWT<TestClaims>(jwtString: signed) {
                 check(jwt: decoded, algorithm: "RS256")
                 
+                XCTAssertEqual(decoded.validateClaims(), .success, "Validation failed")
+            }
+            else {
+                XCTFail("Failed to decode")
+            }
+        }
+        else {
+            XCTFail("Failed to sign")
+        }
+        
+        // HMAC key
+        if let hmacData = hmacKey.data(using: .utf8),
+            let signed = try? jwt.sign(using: .hs256(key: hmacData))
+        {
+            let ok = JWT<TestClaims>.verify(signed, using: .hs256(key: hmacData))
+            XCTAssertTrue(ok, "Verification failed")
+            
+            if let decoded = try? JWT<TestClaims>(jwtString: signed) {
+                check(jwt: decoded, algorithm: "HS256")
                 XCTAssertEqual(decoded.validateClaims(), .success, "Validation failed")
             }
             else {

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -205,20 +205,6 @@ class TestJWT: XCTestCase {
         jwt.claims.iat = Date(timeIntervalSince1970: 1485949565.58463)
         jwt.claims.exp = Date(timeIntervalSince1970: 2485949565.58463)
         jwt.claims.nbf = Date(timeIntervalSince1970: 1485949565.58463)
-        // encode
-        if let encoded = try? jwt.sign(using: .none){
-            if let decoded = try? JWT<TestClaims>(jwtString: encoded) {
-                check(jwt: decoded, algorithm: "none")
-                
-                XCTAssertEqual(decoded.validateClaims(), .success, "Validation failed")
-            }
-            else {
-                XCTFail("Failed to decode")
-            }
-        }
-        else {
-            XCTFail("Failed to encode")
-        }
         
         // public key
         if let signed = try? jwt.sign(using: .rs384(privateKey: rsaPrivateKey)) {
@@ -285,20 +271,6 @@ class TestJWT: XCTestCase {
         jwt.claims.iat = Date(timeIntervalSince1970: 1485949565.58463)
         jwt.claims.exp = Date(timeIntervalSince1970: 2485949565.58463)
         jwt.claims.nbf = Date(timeIntervalSince1970: 1485949565.58463)
-        // encode
-        if let encoded = try? jwt.sign(using: .none){
-            if let decoded = try? JWT<TestClaims>(jwtString: encoded) {
-                check(jwt: decoded, algorithm: "none")
-                
-                XCTAssertEqual(decoded.validateClaims(), .success, "Validation failed")
-            }
-            else {
-                XCTFail("Failed to decode")
-            }
-        }
-        else {
-            XCTFail("Failed to encode")
-        }
         
         // public key
         if let signed = try? jwt.sign(using: .rs512(privateKey: rsaPrivateKey)) {


### PR DESCRIPTION
This pull requests adds support for symmetric key signing and verifying using the BlueCryptor implementation of HMAC. 

This means that you can use the same key for signing and verifying JWTs and supporting this is required by the JWT [spec](https://tools.ietf.org/html/rfc7519#section-8).

I have added a case for HMAC to the existing signing and verifying tests.