### PR TITLE
Add podspec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The latest version of Swift-JWT requires **Swift 4.0** or later. You can downloa
 
 ## Usage
 
+### Swift Package Manager
+
 #### Add dependencies
 Add the `Swift-JWT` package to the dependencies within your application’s `Package.swift` file. Substitute `"x.x.x"` with the latest `Swift-JWT` [release](https://github.com/IBM-Swift/Kitura-Session/releases).
 ```swift
@@ -47,6 +49,12 @@ Add `SwiftJWT` to your target's dependencies:
 import SwiftJWT
 ```
 
+### Cocoapods
+
+To include `Swift-JWT` in a project using CocoaPods, add `SwiftJWT` to your Podfile:
+```
+pod 'SwiftJWT'
+```
 ## Getting Started
 
 ### The JWT model

--- a/SwiftJWT.podspec
+++ b/SwiftJWT.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.module_name  = 'SwiftJWT'
   s.ios.deployment_target = "10.3"
   s.source       = { :git => "https://github.com/IBM-Swift/Swift-JWT.git", :tag => s.version }
-  s.source_files  = "Sources/SwiftJWT/*.swift", "Sources/SwiftJWT/ClaimsExamples/*.swift"
+  s.source_files  = "Sources/**/*.swift"
   s.dependency 'BlueRSA', '~> 1.0'
   s.dependency 'LoggerAPI', '~> 1.7'
   s.dependency 'KituraContracts', '~> 1.1'

--- a/SwiftJWT.podspec
+++ b/SwiftJWT.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name         = "SwiftJWT"
+  s.version      = "3.0.0"
+  s.summary      = "An implementation of JSON Web Token using Swift."
+  s.homepage     = "https://github.com/IBM-Swift/Swift-JWT"
+  s.license      = { :type => "Apache License, Version 2.0" }
+  s.authors      = 'IBM'
+  s.module_name  = 'SwiftJWT'
+  s.ios.deployment_target = "10.3"
+  s.source       = { :git => "https://github.com/IBM-Swift/Swift-JWT.git", :tag => s.version }
+  s.source_files  = "Sources/SwiftJWT/*.swift"
+  s.dependency 'BlueRSA', '~> 1.0'
+end

--- a/SwiftJWT.podspec
+++ b/SwiftJWT.podspec
@@ -8,6 +8,9 @@ Pod::Spec.new do |s|
   s.module_name  = 'SwiftJWT'
   s.ios.deployment_target = "10.3"
   s.source       = { :git => "https://github.com/IBM-Swift/Swift-JWT.git", :tag => s.version }
-  s.source_files  = "Sources/SwiftJWT/*.swift"
+  s.source_files  = "Sources/SwiftJWT/*.swift", "Sources/SwiftJWT/ClaimsExamples/*.swift"
   s.dependency 'BlueRSA', '~> 1.0'
+  s.dependency 'LoggerAPI', '~> 1.7'
+  s.dependency 'KituraContracts', '~> 1.1'
+  s.dependency 'BlueCryptor', '~> 1.0'
 end


### PR DESCRIPTION
This PR adds a podspec file for pushing SwiftJWT to Cocoapods. 
This allows people to use JTW's from iOS apps.