### PR TITLE
Docs: Add migration guide for SwiftJWT 2 -> 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The method returns `ValidateClaimsResult` - an struct that list the various reas
 If the validation succeeds `ValidateClaimsResult.success` is returned.
 
 ```swift
-let validationResult = validateClaims()
+let validationResult = verified.validateClaims()
 if validationResult != .success {
     print("Claims validation failed: ", validationResult)
 }

--- a/migration.md
+++ b/migration.md
@@ -1,6 +1,6 @@
 ## Upgrading to Swift-JWT 3.0
 
-Swift-JWT version 3.0 adds Codable conformance to JWT's for easier encoding and decoding. This release includes breaking changes to the Swift-JWT API and the following is a guide for converting from Swift-JWT Version 2.* to Swift-JWT Version 3.*
+Swift-JWT version 3.0 adds Codable conformance to JWT's for easier encoding and decoding. This release includes breaking changes to the Swift-JWT API and the following is a guide for converting from Swift-JWT 2.0 to Swift-JWT 3.0
 
 ### Header:
 
@@ -9,6 +9,7 @@ The `Header` struct is now Codable and has fixed fields representing the possibl
 ```swift
 // Swift-JWT 2.0
 let header = Header([.typ:"JWT", .kid:"KeyID"])
+
 // Swift-JWT 3.0
 let header = Header(typ: "JWT", kid: "KeyID")
 ```
@@ -16,21 +17,24 @@ These values can then accessed directly:
 ```swift
 // Swift-JWT 2.0
 let keyID = header["kid"]
+
 // Swift-JWT 3.0
 let keyID = header.kid
 ```
 
 ### Claims:
-The JWT `Claims` has been changed to be a protocol. This means that instead of intializing a fixed `Claims` struct with a `[String: Any]` dictionary, you define and intialize your own object that conforms to claims. Alternatively, you can use one of the provided `Claims` Examples. This change adds compile time safety since your claims are defined types instead of `Any` and allows `Claims` to conform to Codable.
+The JWT `Claims` has been changed to be a protocol. This means that instead of intializing a fixed `Claims` struct with a `[String: Any]` dictionary, you define and intialize your own object that conforms to claims. Alternatively, you can use one of the [example Claims implementations](https://github.com/IBM-Swift/Swift-JWT/tree/master/Sources/SwiftJWT/ClaimsExamples) provided.
 
 ```swift
 // Swift-JWT 2.0
 let myClaims = Claims(["iss":"Kitura"])
+
 // Swift-JWT 3.0, User defined claims
 struct MyClaims: Claims {
     let sub: String
 }
 let myClaims = MyClaims(iss: "Kitura")
+
 // Swift-JWT 3.0, Using Standard Claims
 let myClaims = ClaimsStandardJWT(iss: "Kitura")
 ```
@@ -42,9 +46,11 @@ The `Algorithm` enum has been removed and replaced with `JWTSigner` and `JWTVerf
 ```swift
 let privateKey = "<PrivateKey>".data(using: .utf8)!
 let publicKey = "<PublicKey>".data(using: .utf8)!
+
 // Swift-JWT 2.0
 let signer = Algorithm.rs256(privateKey, .privateKey)
 let verifier = Algorithm.rs256(publicKey, .publicKey)
+
 // Swift-JWT 3.0
 let signer = JWTSigner.rs256(privateKey: privateKey)
 let verifier = JWTVerifier.rs256(publicKey: publicKey)
@@ -55,16 +61,52 @@ let verifier = JWTVerifier.rs256(publicKey: publicKey)
 ### JWT:
 
  - The `JWT` Struct is now generic over a `Claims` object.
- - The `sign` function returns `String` instead of `String?`.  
- - The `verify` function no longer throws.
- - The `validateClaims` function now only checks time based claims.  
+ 
+ ```swift
+ // Swift-JWT 2.0
+ JWT
+ 
+ // Swift-JWT 3.0
+ JWT<MyClaims>
+ ```
+ 
+ - The `sign` function takes a `JWTSigner` and returns `String` instead of `String?`.  
+ 
+ ```swift
+ // Swift-JWT 2.0
+let signedJWT: String? = try jwt.sign(using: Algorithm.rs256(key, .privateKey))
 
+ // Swift-JWT 3.0
+ let signedJWT: String = try jwt.sign(using: JWTSigner.rs256(privateKey: key))
+```
+ 
+ - The `verify` function takes a `JWTVerifier` and no longer throws.
+ 
+ ```swift
+ // Swift-JWT 2.0
+ let verified = try JWT.verify(signedJWT, using: Algorithm.rs256(key, .publicKey))
+ 
+ // Swift-JWT 3.0
+ let verified = JWT<MyClaims>.verify(signedJWT, using: JWTVerifier.rs256(publicKey: key))
+```
+ 
+ - The `validateClaims` function now only checks registered JWT date based claims.  
+ 
+ ```swift
+ // Swift-JWT 2.0
+ let validationResult = jwt.validateClaims(issuer: "issuer", audience: "clientID")
+
+ // Swift-JWT 3.0
+ let validationResult = jwt.validateClaims()
+ let validateOthers = jwt.issuer == "issuer" && jwt.audience == "clientID"
+ ```
 
 The `encode()` function has been removed. To encode a JWT without signing it use the `none` JWTSigner:
 
 ```swift
 // Swift-JWT 2.0
 let encodedJWT = try jwt.encoded()
+
 // Swift-JWT 3.0
 let encodedJWT = try jwt.sign(using: .none)
 ```
@@ -73,20 +115,17 @@ The `decode()` function has been replaced with an init from String:
 ```swift
 // Swift-JWT 2.0
 let decodedJWT = try JWT.decode(encodedJWT)
+
 // Swift-JWT 3.0
 let decodedJWT = try JWT<MyClaims>(jwtString: encodedJWT)
 ```
 
 
 ## Removed APIs
-To Clean up the Swift-JWT API, the following public structs and enums have been removed. They are either no longer necessary or not a part of using JWTs.
+ As a result of the new API, a number of types are now redundant and have been removed. These include:
 
- - The `Supported` enum has been removed.
-
- - The struct `Base64URL` has been made internal.
-
- - The struct `Hash` has been removed.
-
- - The `RSAKeyType` enum has been made internal since you no longer need to provide a KeyType with `JWTSigner` and `JWTVerifier`.
-
- - The `ClaimKeys` enum has been removed. See [ClaimsExamples](https://github.com/IBM-Swift/Swift-JWT/tree/master/Sources/SwiftJWT/ClaimsExamples) for example `Claims` you can use.
+ - `Supported`
+ - `Base64URL` 
+ -  `Hash` 
+ - `RSAKeyType` 
+ - `ClaimKeys` 

--- a/migration.md
+++ b/migration.md
@@ -64,10 +64,10 @@ let verifier = JWTVerifier.rs256(publicKey: publicKey)
  
  ```swift
  // Swift-JWT 2.0
- JWT
+ let myJWT: JWT
  
  // Swift-JWT 3.0
- JWT<MyClaims>
+ let myJWT: JWT<MyClaims>
  ```
  
  - The `sign` function takes a `JWTSigner` and returns `String` instead of `String?`.  
@@ -90,7 +90,7 @@ let signedJWT: String? = try jwt.sign(using: Algorithm.rs256(key, .privateKey))
  let verified = JWT<MyClaims>.verify(signedJWT, using: JWTVerifier.rs256(publicKey: key))
 ```
  
- - The `validateClaims` function now only checks registered JWT date based claims.  
+ - The `validateClaims` function now only checks the `iat`, `exp`, and `nbf` claims are valid at the current point in time.  
  
  ```swift
  // Swift-JWT 2.0
@@ -98,7 +98,7 @@ let signedJWT: String? = try jwt.sign(using: Algorithm.rs256(key, .privateKey))
 
  // Swift-JWT 3.0
  let validationResult = jwt.validateClaims()
- let validateOthers = jwt.issuer == "issuer" && jwt.audience == "clientID"
+ let validateOthers = jwt.iss == "issuer" && jwt.aud == "clientID"
  ```
 
 The `encode()` function has been removed. To encode a JWT without signing it use the `none` JWTSigner:

--- a/migration.md
+++ b/migration.md
@@ -1,0 +1,107 @@
+A guide for converting from Swift-JWT Version 2.* to Swift-JWT Version 3.
+
+## Changed Structs
+
+The following Structs have been changed:
+
+### Header:
+
+To initialise the `Header` class, instead of providing a `[HeaderKey: Any]` dictionary:
+
+```swift
+let header = Header([.typ:"JWT", .kid:"KeyID"])
+```
+
+Set the fields directly:
+```swift
+let header = Header(typ: "JWT", kid: "KeyID)
+```
+
+Instead of accessing the fields using subscripting:
+```swift
+let keyID = header["kid"]
+```
+Access the Header fields directly:
+```swift
+let keyID = header.kid
+```
+
+### Claims:
+
+`Claims` is now a protocol instead of a struct. Instead of initialising the claims struct using a `[String:Any]` dictionary:
+```swift
+let myClaims = Claims(["name":"Kitura"])
+```
+
+Define your object conforming to `Claims` and initialise it:
+```swift
+struct MyClaims: Claims {
+    let name: String
+}
+let myClaims = MyClaims(name: "Kitura")
+```
+
+### Algorithm:
+
+The `Algorithm` enum has been removed and replaced with `JWTSigner` and `JWTVerfier` structs.
+
+Instead of creating Algorithms:
+```swift
+let privateKey = "<PrivateKey>".data(using: .utf8)!
+let publicKey = "<publicKey>".data(using: .utf8)!
+let signer = Algorithm.rs256(privateKey, .privateKey)
+let verifier = Algorithm.rs256(publicKey, .publicKey)
+```
+Create a `JWTSigner` and `JWTVerfier`:
+```swift
+let privateKey = "<PrivateKey>".data(using: .utf8)!
+let publicKey = "<publicKey>".data(using: .utf8)!
+let signer = JWTSigner.rs256(privateKey: privateKey)
+let verifier = Algorithm.rs256(publicKey: publicKey)
+```
+
+### JWT:
+
+The `JWT` Struct is now generic over a `Claims` struct.
+```swift
+JWT<MyClaims>
+```
+
+The `sign` function returns `String` instead of `String?`.  
+The `verify` function no longer throws.
+
+The `encode()` function:
+```swift
+let encodedJWT = try jwt.encoded()
+```
+Has been removed. To encode a JWT without signing it use:
+```swift
+let encodedJWT = try jwt.sign(using: .none)
+```
+
+The `decode()` function:
+```swift
+let decodedJWT = try JWT.decode(encodedJWT)
+```
+Has been replaced with an init from String:
+```swift
+let decodedJWT = try JWT<MyClaims>(jwtString: encodedJWT)
+```
+
+The validateClaims function now only checks time based claims.  
+
+## Removed APIs
+
+```swift
+JWT.isSupported(name: String) -> Supported
+```
+
+To see supported Algorithms, check the README.md or inspect the initialisers for JWTSigner and JWTVerifier.
+
+The struct `Base64URL` has been made internal.
+
+The struct `Hash` has been removed.
+
+The `RSAKeyType` enum has been made internal
+
+The `ClaimKeys` enum has been removed. See [ClaimsExamples](https://github.com/IBM-Swift/Swift-JWT/tree/master/Sources/SwiftJWT/ClaimsExamples) for registered claims.

--- a/migration.md
+++ b/migration.md
@@ -1,105 +1,92 @@
-A guide for converting from Swift-JWT Version 2.* to Swift-JWT Version 3.
+## Upgrading to Swift-JWT 3.0
 
-## Changed Structs
-
-The following Structs have been changed:
+Swift-JWT version 3.0 adds Codable conformance to JWT's for easier encoding and decoding. This release includes breaking changes to the Swift-JWT API and the following is a guide for converting from Swift-JWT Version 2.* to Swift-JWT Version 3.*
 
 ### Header:
 
-To initialise the `Header` class, instead of providing a `[HeaderKey: Any]` dictionary:
+The `Header` struct is now Codable and has fixed fields representing the possible headers. As a result, the Header is now intialized by setting the field values:
 
 ```swift
+// Swift-JWT 2.0
 let header = Header([.typ:"JWT", .kid:"KeyID"])
-```
-
-Set the fields directly:
-```swift
+// Swift-JWT 3.0
 let header = Header(typ: "JWT", kid: "KeyID")
 ```
-
-Instead of accessing the fields using subscripting:
+These values can then accessed directly:
 ```swift
+// Swift-JWT 2.0
 let keyID = header["kid"]
-```
-Access the Header fields directly:
-```swift
+// Swift-JWT 3.0
 let keyID = header.kid
 ```
 
 ### Claims:
-In Swift-JWT 2.0, you initialize the `Claims` struct using a dictionary:
+The JWT `Claims` has been changed to be a protocol. This means that instead of intializing a fixed `Claims` struct with a `[String: Any]` dictionary, you define and intialize your own object that conforms to claims. Alternatively, you can use one of the provided `Claims` Examples. This change adds compile time safety since your claims are defined types instead of `Any` and allows `Claims` to conform to Codable.
+
 ```swift
-let myClaims = Claims(["name":"Kitura"])
-```
- In Swift-JWT 3.0, instead you define an object conforming to claims:
- ```swift
+// Swift-JWT 2.0
+let myClaims = Claims(["iss":"Kitura"])
+// Swift-JWT 3.0, User defined claims
 struct MyClaims: Claims {
-    let name: String
+    let sub: String
 }
-let myClaims = MyClaims(name: "Kitura")
+let myClaims = MyClaims(iss: "Kitura")
+// Swift-JWT 3.0, Using Standard Claims
+let myClaims = ClaimsStandardJWT(iss: "Kitura")
 ```
 
 ### Algorithm:
 
-The `Algorithm` enum has been removed and replaced with `JWTSigner` and `JWTVerfier` structs.
+The `Algorithm` enum has been removed and replaced with `JWTSigner` and `JWTVerfier` structs. This change removes the requirement to specify the Key type and allows more signing and verifying algorithms to be added later.
 
-Instead of creating Algorithms:
 ```swift
 let privateKey = "<PrivateKey>".data(using: .utf8)!
-let publicKey = "<publicKey>".data(using: .utf8)!
+let publicKey = "<PublicKey>".data(using: .utf8)!
+// Swift-JWT 2.0
 let signer = Algorithm.rs256(privateKey, .privateKey)
 let verifier = Algorithm.rs256(publicKey, .publicKey)
-```
-Create a `JWTSigner` and `JWTVerfier`:
-```swift
-let privateKey = "<PrivateKey>".data(using: .utf8)!
-let publicKey = "<publicKey>".data(using: .utf8)!
+// Swift-JWT 3.0
 let signer = JWTSigner.rs256(privateKey: privateKey)
-let verifier = Algorithm.rs256(publicKey: publicKey)
+let verifier = JWTVerifier.rs256(publicKey: publicKey)
 ```
+
+ - The `isSupported` function has been removed. To see supported Algorithms, check the [README](https://github.com/IBM-Swift/Swift-JWT#supported-algorithms) or inspect the initialisers for `JWTSigner` and `JWTVerifier`.
 
 ### JWT:
 
-The `JWT` Struct is now generic over a `Claims` struct.
-```swift
-JWT<MyClaims>
-```
+ - The `JWT` Struct is now generic over a `Claims` object.
+ - The `sign` function returns `String` instead of `String?`.  
+ - The `verify` function no longer throws.
+ - The `validateClaims` function now only checks time based claims.  
 
-The `sign` function returns `String` instead of `String?`.  
-The `verify` function no longer throws.
 
-The `encode()` function:
+The `encode()` function has been removed. To encode a JWT without signing it use the `none` JWTSigner:
+
 ```swift
+// Swift-JWT 2.0
 let encodedJWT = try jwt.encoded()
-```
-Has been removed. To encode a JWT without signing it use:
-```swift
+// Swift-JWT 3.0
 let encodedJWT = try jwt.sign(using: .none)
 ```
 
-The `decode()` function:
+The `decode()` function has been replaced with an init from String:
 ```swift
+// Swift-JWT 2.0
 let decodedJWT = try JWT.decode(encodedJWT)
-```
-Has been replaced with an init from String:
-```swift
+// Swift-JWT 3.0
 let decodedJWT = try JWT<MyClaims>(jwtString: encodedJWT)
 ```
 
-The validateClaims function now only checks time based claims.  
 
 ## Removed APIs
+To Clean up the Swift-JWT API, the following public structs and enums have been removed. They are either no longer necessary or not a part of using JWTs.
 
-```swift
-JWT.isSupported(name: String) -> Supported
-```
+ - The `Supported` enum has been removed.
 
-To see supported Algorithms, check the README.md or inspect the initialisers for JWTSigner and JWTVerifier.
+ - The struct `Base64URL` has been made internal.
 
-The struct `Base64URL` has been made internal.
+ - The struct `Hash` has been removed.
 
-The struct `Hash` has been removed.
+ - The `RSAKeyType` enum has been made internal since you no longer need to provide a KeyType with `JWTSigner` and `JWTVerifier`.
 
-The `RSAKeyType` enum has been made internal
-
-The `ClaimKeys` enum has been removed. See [ClaimsExamples](https://github.com/IBM-Swift/Swift-JWT/tree/master/Sources/SwiftJWT/ClaimsExamples) for registered claims.
+ - The `ClaimKeys` enum has been removed. See [ClaimsExamples](https://github.com/IBM-Swift/Swift-JWT/tree/master/Sources/SwiftJWT/ClaimsExamples) for example `Claims` you can use.

--- a/migration.md
+++ b/migration.md
@@ -14,7 +14,7 @@ let header = Header([.typ:"JWT", .kid:"KeyID"])
 
 Set the fields directly:
 ```swift
-let header = Header(typ: "JWT", kid: "KeyID)
+let header = Header(typ: "JWT", kid: "KeyID")
 ```
 
 Instead of accessing the fields using subscripting:
@@ -27,14 +27,12 @@ let keyID = header.kid
 ```
 
 ### Claims:
-
-`Claims` is now a protocol instead of a struct. Instead of initialising the claims struct using a `[String:Any]` dictionary:
+In Swift-JWT 2.0, you initialize the `Claims` struct using a dictionary:
 ```swift
 let myClaims = Claims(["name":"Kitura"])
 ```
-
-Define your object conforming to `Claims` and initialise it:
-```swift
+ In Swift-JWT 3.0, instead you define an object conforming to claims:
+ ```swift
 struct MyClaims: Claims {
     let name: String
 }


### PR DESCRIPTION
This PR adds a migration guide for how to change from the old API's to the SwiftJWT 3 API's.