### PR TITLE
Patch: Add `ClaimsStandardJWT` initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ The JWTEncoder and JWTDecoder classes encode and decode JWT Strings using the sa
 Because JWTEncoder and JWTDecoder conform to [KituraContract's](https://github.com/IBM-Swift/KituraContracts/blob/master/Sources/KituraContracts/Contracts.swift) BodyEncoder and BodyDecoder protocols, they can be used as a [custom coder](https://developer.ibm.com/swift/2018/09/01/kitura-custom-encoders-and-decoders/) in Codable routes for sending and receiving JWTs:
 
 ```swift
- router.encoders[MediaType(type: .application, subtype: "jwt")] = jwtEncoder
- router.decoders[MediaType(type: .application, subtype: "jwt")] = jwtDecoder
+ router.encoders[MediaType(type: .application, subType: "jwt")] = { return jwtEncoder }
+ router.decoders[MediaType(type: .application, subType: "jwt")] = { return jwtDecoder }
 ```
 
 This allows for the use of JWT's in information exchange. By sending and receiving JWT's you can ensure the sending is who they say they are and verify the content hasn't been tampered with.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Therefore, a JWT typically looks like the following: xxxxx.yyyyy.zzzzz
 #### Header
 
 The Header struct contains the fields of the JSON Web Token header as defined by [RFC7515](https://tools.ietf.org/html/rfc7515#section-4).   
-The "typ" header will default to "JWT". The "alg" header will be set the algorithm name when you sign the JWT.  
+The "typ" header will default to "JWT". The "alg" header will be set to the algorithm name when you sign the JWT.  
 The other Header fields can be set when initializing the Header or by changing them directly on the Header object.
 
 ```swift
@@ -150,7 +150,7 @@ Initialize a JWTVerifier using the static function corresponding to the desired 
 ```swift
 let jwtVerifier = JWTVerifier.rs256(publicKey: publicKey)
 ```
-To verify a signed JWT string, call the `sign` function on your JWT instance, passing in a JWTSigner:
+To verify a signed JWT string, call the static `verify` function, passing in your JWT string and the JWTVerifier:
 
 ```swift
 let verified = JWT<MyClaims>.verify(signedJWT, using: jwtVerifier)

--- a/Sources/SwiftJWT/ClaimsExamples/ClaimsMicroProfile.swift
+++ b/Sources/SwiftJWT/ClaimsExamples/ClaimsMicroProfile.swift
@@ -16,11 +16,12 @@
 
 import Foundation
 
-// MARK MicroProfileClaims
+// MARK ClaimsMicroProfile
 
 /// A class representing the MicroProfile claims as listed in [MicroProfile specs](http://microprofile.io/project/eclipse/microprofile-jwt-auth/spec/src/main/asciidoc/interoperability.asciidoc).
 public class ClaimsMicroProfile: Claims {
     
+    /// Initialize a `ClaimsMicroProfile`
     public init(
         iss: String,
         sub: String,
@@ -38,6 +39,7 @@ public class ClaimsMicroProfile: Claims {
         self.upn = upn
         self.groups = groups
     }
+    
     /**
      The MP-JWT issuer. [RFC7519, Section 4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)
      */

--- a/Sources/SwiftJWT/ClaimsExamples/ClaimsOpenID.swift
+++ b/Sources/SwiftJWT/ClaimsExamples/ClaimsOpenID.swift
@@ -16,12 +16,12 @@
 
 import Foundation
 
-// MARK OpenIDClaims
+// MARK ClaimsOpenID
 
 /// A class representing OpenID related claims as decsribed in [OpenID specs](http://openid.net/specs/openid-connect-core-1_0.html).
 public class ClaimsOpenID: Claims {
     
-    /// Initalise the OpenIDClaims
+    /// Initalise the `ClaimsOpenID`
     public init(
         iss: String,
         sub: String,

--- a/Sources/SwiftJWT/ClaimsExamples/ClaimsStandardJWT.swift
+++ b/Sources/SwiftJWT/ClaimsExamples/ClaimsStandardJWT.swift
@@ -16,10 +16,29 @@
 
 import Foundation
 
-// MARK StandardJWTClaims
+// MARK ClaimsStandardJWT
 
 /// A class representing the Standard JWT claims as described in [RFC7519](https://tools.ietf.org/html/rfc7519#section-4.1).
 public class ClaimsStandardJWT: Claims {
+    
+    /// Initialize a `ClaimsStandardJWT`
+    public init(
+        iss: String? = nil,
+        sub: String? = nil,
+        aud: [String]? = nil,
+        exp: Date? = nil,
+        nbf: Date? = nil,
+        iat: Date? = nil,
+        jti: String? = nil
+        ) {
+        self.iss = iss
+        self.sub = sub
+        self.aud = aud
+        self.exp = exp
+        self.nbf = nbf
+        self.iat = iat
+        self.jti = jti
+    }
     
     /**
      The "iss" (issuer) claim identifies the principal that issued the


### PR DESCRIPTION
The Swift-JWT library has some example claims that are recognized by external parties. One of these is the Standard JWT Claims which are represented by ClaimsStandardJWT. 

This PR adds a missing a public initializer meaning it can be used by someone who wants to just use the standard claims.

It also fixes some mistakes in the README and Jazzy docs.