### PR TITLE
Changed date strategy to seconds since 1970

### DIFF
--- a/Sources/SwiftJWT/Claims.swift
+++ b/Sources/SwiftJWT/Claims.swift
@@ -76,7 +76,9 @@ public extension Claims {
     }
     
     func encode() throws -> String {
-        let data = try JSONEncoder().encode(self)
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.dateEncodingStrategy = .secondsSince1970
+        let data = try jsonEncoder.encode(self)
         return data.base64urlEncodedString()
     }
 }

--- a/Sources/SwiftJWT/Header.swift
+++ b/Sources/SwiftJWT/Header.swift
@@ -94,7 +94,9 @@ public struct Header: Codable {
     }
     
     func encode() throws -> String  {
-        let data = try JSONEncoder().encode(self)
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.dateEncodingStrategy = .secondsSince1970
+        let data = try jsonEncoder.encode(self)
         return data.base64urlEncodedString()
     }
 }

--- a/Sources/SwiftJWT/JWT.swift
+++ b/Sources/SwiftJWT/JWT.swift
@@ -73,8 +73,10 @@ public struct JWT<T: Claims>: Codable {
         guard JWT.verify(jwtString, using: verifier) else {
             throw JWTError.failedVerification
         }
-        let header = try JSONDecoder().decode(Header.self, from: headerData)
-        let claims = try JSONDecoder().decode(T.self, from: claimsData)
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .secondsSince1970
+        let header = try jsonDecoder.decode(Header.self, from: headerData)
+        let claims = try jsonDecoder.decode(T.self, from: claimsData)
         self.header = header
         self.claims = claims
     }

--- a/Sources/SwiftJWT/JWTDecoder.swift
+++ b/Sources/SwiftJWT/JWTDecoder.swift
@@ -212,8 +212,10 @@ private struct _JWTKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContaine
     // Those types will be a `Header` object and a generic `Claims` object.
     func decode<T : Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
         decoder.codingPath.append(key)
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .secondsSince1970
         if key.stringValue == "header" {
-            let header = try JSONDecoder().decode(Header.self, from: self.header)
+            let header = try jsonDecoder.decode(Header.self, from: self.header)
             decoder.keyID = header.kid
             guard let decodedHeader = header as? T else {
                 throw DecodingError.typeMismatch(T.self, DecodingError.Context(codingPath: codingPath, debugDescription: "Type of header key was not a JWT Header"))
@@ -221,7 +223,7 @@ private struct _JWTKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContaine
             return decodedHeader
         } else
         if key.stringValue == "claims" {
-            return try JSONDecoder().decode(type, from: claims)
+            return try jsonDecoder.decode(type, from: claims)
         } else {
             throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: codingPath, debugDescription: "value not found for provided key"))
         }

--- a/Sources/SwiftJWT/JWTEncoder.swift
+++ b/Sources/SwiftJWT/JWTEncoder.swift
@@ -151,6 +151,8 @@ fileprivate class _JWTEncoder: Encoder {
         mutating func encode<T : Encodable>(_ value: T, forKey key: Key) throws {
             self.codingPath.append(key)
             let fieldName = key.stringValue
+            let jsonEncoder = JSONEncoder()
+            jsonEncoder.dateEncodingStrategy = .secondsSince1970
             if fieldName == "header" {
                 guard var _header = value as? Header else {
                     throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Failed to encode into header CodingKey"))
@@ -163,10 +165,10 @@ fileprivate class _JWTEncoder: Encoder {
                     encoder.jwtSigner = keyIDJWTSigner
                 }
                 _header.alg = encoder.jwtSigner?.name
-                let data = try JSONEncoder().encode(_header)
+                let data = try jsonEncoder.encode(_header)
                 encoder.header = data.base64urlEncodedString()
             } else if fieldName == "claims" {
-                let data = try JSONEncoder().encode(value)
+                let data = try jsonEncoder.encode(value)
                 encoder.claims = data.base64urlEncodedString()
             }
         }

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -402,6 +402,7 @@ class TestJWT: XCTestCase {
         jwt.claims.sub = "1234567890"
         jwt.claims.name = "John Doe"
         jwt.claims.admin = true
+        jwt.claims.iat = Date(timeIntervalSince1970: 1516239022)
         do {
             let jwtString = try rsaJWTEncoder.encodeToString(jwt)
             let decodedJWTString = try JWT<TestClaims>(jwtString: jwtString)
@@ -424,6 +425,7 @@ class TestJWT: XCTestCase {
         jwt.claims.sub = "1234567890"
         jwt.claims.name = "John Doe"
         jwt.claims.admin = true
+        jwt.claims.iat = Date(timeIntervalSince1970: 1516239022)
         do {
             let decodedJWT = try rsaJWTDecoder.decode(JWT<TestClaims>.self, fromString: rsaEncodedTestClaimJWT)
             jwt.header.alg = "RS256"

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -26,7 +26,7 @@ let rsaJWTEncoder = JWTEncoder(jwtSigner: .rs256(privateKey: rsaPrivateKey))
 let rsaJWTDecoder = JWTDecoder(jwtVerifier: .rs256(publicKey: rsaPublicKey))
 let certPrivateKey = read(fileName: "cert_private_key")
 let certificate = read(fileName: "certificate")
-let rsaEncodedTestClaimJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwic3ViIjoiMTIzNDU2Nzg5MCJ9.WJHaxAjhLu7wkw2J3B7ZpW-pnX-WEDJuy7l46nHZRWtZrH_4f8724v-4V48UlHtEgQpUXCHyGRyWPgPJCdGIfy2vD5GBoMJ1kdNWQa0UVOajTk0omUIloBPKgo-45m3w15ub-_4bihyZOI8dCK9zk5vjvUGnzdKartNi9AN5kNM"
+let rsaEncodedTestClaimJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwic3ViIjoiMTIzNDU2Nzg5MCIsImlhdCI6MTUxNjIzOTAyMn0.HbPVSMBtR3l0zyrHIlGRyXkNECgE0RrQreebA2xuIWhN-64MP29-lf8lg5pWKk3gTrnbOxEpek5AvBNgz4VK34enkzhrrMKonBywvZZ8CQtM5FlArgx5ZQqxjD32B7WCqlDOelly1W2rlFNIopBit-OuKBw1ioxQwzDMLb1Ol3Q"
 let certificateEncodedTestClaimJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwic3ViIjoiMTIzNDU2Nzg5MCJ9.CpnzQLuWGfH5Kba36vg0ZZKBnzwlrIgapFVfBfk_nea-eej84ktHZANqIeolskZopRJ4DQ3oaLtHWEg16-ZsujxmkOdiAIbk0-C4QLOVFLZH78WLZAqkyNLS8rFuK9hloLNwz1j6VVUd1f0SOT-wIRzL0_0VRYqQd1bVcCj7wc7BmXENlOfHY7KGHS-6JX-EClT1DygDSoCmdvBExBf3vx0lwMIbP4ryKkyhOoU13ZfSUt1gpP9nZAfzqfRTPxZc_f7neiAlMlF6SzsedsskRCNegW8cg5e_NuVmZZkj0_bnswXFDMmIaxiPdtOEWkmyEOca-EHSwbO5PgCgXOIrgg"
 // A `TestClaims` encoded using HMAC with "Super Secret Key" from "www.jwt.io"
 let hmacEncodedTestClaimJWT = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwic3ViIjoiMTIzNDU2Nzg5MCJ9.8kIE0ZCq1Vw7aW1kACpgJLcgY2DpTXgO6P5T3cdCuTs"
@@ -520,6 +520,8 @@ class TestJWT: XCTestCase {
             XCTAssertEqual(decoded.claims.sub, "1234567890", "Wrong .sub in decoded")
             XCTAssertEqual(decoded.claims.name, "John Doe", "Wrong .name in decoded")
             XCTAssertEqual(decoded.claims.admin, true, "Wrong .admin in decoded")
+            XCTAssertEqual(decoded.claims.iat, Date(timeIntervalSince1970: 1516239022), "Wrong .iat in decoded")
+            
             
             XCTAssertEqual(decoded.validateClaims(), .success, "Validation failed")
         }
@@ -548,6 +550,10 @@ class TestJWT: XCTestCase {
         else {
             XCTFail("Failed to decode")
         }
+    }
+    
+    func testDateEncodingStrategy() {
+        
     }
 }
 

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -551,10 +551,6 @@ class TestJWT: XCTestCase {
             XCTFail("Failed to decode")
         }
     }
-    
-    func testDateEncodingStrategy() {
-        
-    }
 }
 
 func read(fileName: String) -> Data {


### PR DESCRIPTION
This repo uses JSONEncoder and JSONDecoder to encode and decode dates. The default date strategy for these is seconds since 2000. The [JWT specs](https://tools.ietf.org/html/rfc7519#section-2) specify that dates should be encoded/decoded as seconds since 1970. 

This PR changes the date encoding strategy and date decoding strategy on the encoders/decoders to the correct date format so that JWT's can be used with other providers.

This change will invalidate the dates on any JWT's encoded using the old system.