### PR TITLE
Added osx, tvOS and watchOS to podspec file

### DIFF
--- a/SwiftJWT.podspec
+++ b/SwiftJWT.podspec
@@ -6,7 +6,10 @@ Pod::Spec.new do |s|
   s.license      = { :type => "Apache License, Version 2.0" }
   s.authors      = 'IBM'
   s.module_name  = 'SwiftJWT'
+  s.osx.deployment_target = "10.12"
   s.ios.deployment_target = "10.3"
+  s.tvos.deployment_target = "10.3"
+  s.watchos.deployment_target = "3.3"
   s.source       = { :git => "https://github.com/IBM-Swift/Swift-JWT.git", :tag => s.version }
   s.source_files  = "Sources/**/*.swift"
   s.dependency 'BlueRSA', '~> 1.0'


### PR DESCRIPTION
This pull request adds tvOS, osx and watchOS to the podspec file so that the pod can be used on those devices.
Since we don't use any platform features this can be added without any code changes.

This is dependent on PR's to LoggerAPI KituraContracts, BlueRSA and BlueCryptor being updated first.