### PR TITLE
feat: Added leeway to validate claims

### DIFF
--- a/Sources/SwiftJWT/JWT.swift
+++ b/Sources/SwiftJWT/JWT.swift
@@ -112,38 +112,24 @@ public struct JWT<T: Claims>: Codable {
     /// This function checks that the "exp" (expiration time) is in the future
     /// and the "iat" (issued at) and "nbf" (not before) headers are in the past,
     ///
+    /// - Parameter leeway: The time in seconds that the JWT can be invalid but still accepted to account for clock differences.
     /// - Returns: A value of `ValidateClaimsResult`.
-    public func validateClaims() -> ValidateClaimsResult {        
-        if let _ = claims.exp {
-            if let expirationDate = claims.exp {
-                if expirationDate < Date() {
-                    return .expired
-                }
-            }
-            else {
-                return .invalidExpiration
+    public func validateClaims(leeway: TimeInterval = 0) -> ValidateClaimsResult {        
+        if let expirationDate = claims.exp {
+            if expirationDate + leeway < Date() {
+                return .expired
             }
         }
         
-        if let _ = claims.nbf {
-            if let notBeforeDate = claims.nbf {
-                if notBeforeDate > Date() {
-                    return .notBefore
-                }
-            }
-            else {
-                return .invalidNotBefore
+        if let notBeforeDate = claims.nbf {
+            if notBeforeDate > Date() + leeway {
+                return .notBefore
             }
         }
         
-        if let _ = claims.iat {
-            if let issuedAtDate = claims.iat {
-                if issuedAtDate > Date() {
-                    return .issuedAt
-                }
-            }
-            else {
-                return .invalidIssuedAt
+        if let issuedAtDate = claims.iat {
+            if issuedAtDate > Date() + leeway {
+                return .issuedAt
             }
         }
         

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -553,6 +553,30 @@ class TestJWT: XCTestCase {
             XCTFail("Failed to decode")
         }
     }
+    
+    func testValidateClaims() {
+        var jwt = JWT(claims: TestClaims(name:"Kitura"))
+        jwt.claims.exp = Date()
+        XCTAssertEqual(jwt.validateClaims(), .expired, "Validation failed")
+        jwt.claims.exp = nil
+        jwt.claims.iat = Date(timeIntervalSinceNow: 10)
+        XCTAssertEqual(jwt.validateClaims(), .issuedAt, "Validation failed")
+        jwt.claims.iat = nil
+        jwt.claims.nbf = Date(timeIntervalSinceNow: 10)
+        XCTAssertEqual(jwt.validateClaims(), .notBefore, "Validation failed")
+    }
+    
+    func testValidateClaimsLeeway() {
+        var jwt = JWT(claims: TestClaims(name:"Kitura"))
+        jwt.claims.exp = Date()
+        XCTAssertEqual(jwt.validateClaims(leeway: 20), .success, "Validation failed")
+        jwt.claims.exp = nil
+        jwt.claims.iat = Date(timeIntervalSinceNow: 10)
+        XCTAssertEqual(jwt.validateClaims(leeway: 20), .success, "Validation failed")
+        jwt.claims.iat = nil
+        jwt.claims.nbf = Date(timeIntervalSinceNow: 10)
+        XCTAssertEqual(jwt.validateClaims(leeway: 20), .success, "Validation failed")
+    }
 }
 
 func read(fileName: String) -> Data {


### PR DESCRIPTION
This PR adds a leeway parameter to the validateClaims function.
This allows a user to set a time interval during which the JWT will still be accepted even if the time claim is not valid. This can be used to take into account clock skew such as the example issue where the iat claim was being mistaken for being in the future.