### PR TITLE
feat: Add leeway to validateClaims

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,10 @@ The following claims are validated if they are present in the `Claims` object:
 
 The method returns `ValidateClaimsResult` - an struct that list the various reasons for validation failure.
 If the validation succeeds `ValidateClaimsResult.success` is returned.
+The `leeway` parameter is the `TimeInterval` in seconds that the Date can be invalid for but still be accepted to account for clock skew.
 
 ```swift
-let validationResult = verified.validateClaims()
+let validationResult = verified.validateClaims(leeway: 10)
 if validationResult != .success {
     print("Claims validation failed: ", validationResult)
 }

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The supported algorithms for signing and verifying JWTs are:
 
 ### Validate claims
 
-The `validateClaims` function validates the Standard Date claims of a JWT instance.
+The `validateClaims` function validates the standard `Date` claims of a JWT instance.
 The following claims are validated if they are present in the `Claims` object:
 - exp (expiration date)
 - nbf (not before date)
@@ -186,7 +186,7 @@ The following claims are validated if they are present in the `Claims` object:
 
 The method returns `ValidateClaimsResult` - an struct that list the various reasons for validation failure.
 If the validation succeeds `ValidateClaimsResult.success` is returned.
-The `leeway` parameter is the `TimeInterval` in seconds that the Date can be invalid for but still be accepted to account for clock skew.
+The `leeway` parameter is the `TimeInterval` in seconds that a standard `Date` claim will be valid outside of the specified time. This can be used to account for clock skew between issuers and verifiers.
 
 ```swift
 let validationResult = verified.validateClaims(leeway: 10)

--- a/Sources/SwiftJWT/JWT.swift
+++ b/Sources/SwiftJWT/JWT.swift
@@ -112,38 +112,24 @@ public struct JWT<T: Claims>: Codable {
     /// This function checks that the "exp" (expiration time) is in the future
     /// and the "iat" (issued at) and "nbf" (not before) headers are in the past,
     ///
+    /// - Parameter leeway: The time in seconds that the JWT can be invalid but still accepted to account for clock differences.
     /// - Returns: A value of `ValidateClaimsResult`.
-    public func validateClaims() -> ValidateClaimsResult {        
-        if let _ = claims.exp {
-            if let expirationDate = claims.exp {
-                if expirationDate < Date() {
-                    return .expired
-                }
-            }
-            else {
-                return .invalidExpiration
+    public func validateClaims(leeway: TimeInterval = 0) -> ValidateClaimsResult {        
+        if let expirationDate = claims.exp {
+            if expirationDate + leeway < Date() {
+                return .expired
             }
         }
         
-        if let _ = claims.nbf {
-            if let notBeforeDate = claims.nbf {
-                if notBeforeDate > Date() {
-                    return .notBefore
-                }
-            }
-            else {
-                return .invalidNotBefore
+        if let notBeforeDate = claims.nbf {
+            if notBeforeDate > Date() + leeway {
+                return .notBefore
             }
         }
         
-        if let _ = claims.iat {
-            if let issuedAtDate = claims.iat {
-                if issuedAtDate > Date() {
-                    return .issuedAt
-                }
-            }
-            else {
-                return .invalidIssuedAt
+        if let issuedAtDate = claims.iat {
+            if issuedAtDate > Date() + leeway {
+                return .issuedAt
             }
         }
         

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -112,7 +112,9 @@ class TestJWT: XCTestCase {
             ("testJWTCoderCycleKeyID", testJWTCoderCycleKeyID),
             ("testJWT", testJWT),
             ("testJWTUsingHMAC", testJWTUsingHMAC),
-            ("testMicroProfile", testMicroProfile)
+            ("testMicroProfile", testMicroProfile),
+            ("testValidateClaims", testValidateClaims),
+            ("testValidateClaimsLeeway", testValidateClaimsLeeway),
         ]
     }
 
@@ -552,6 +554,30 @@ class TestJWT: XCTestCase {
         else {
             XCTFail("Failed to decode")
         }
+    }
+    
+    func testValidateClaims() {
+        var jwt = JWT(claims: TestClaims(name:"Kitura"))
+        jwt.claims.exp = Date()
+        XCTAssertEqual(jwt.validateClaims(), .expired, "Validation failed")
+        jwt.claims.exp = nil
+        jwt.claims.iat = Date(timeIntervalSinceNow: 10)
+        XCTAssertEqual(jwt.validateClaims(), .issuedAt, "Validation failed")
+        jwt.claims.iat = nil
+        jwt.claims.nbf = Date(timeIntervalSinceNow: 10)
+        XCTAssertEqual(jwt.validateClaims(), .notBefore, "Validation failed")
+    }
+    
+    func testValidateClaimsLeeway() {
+        var jwt = JWT(claims: TestClaims(name:"Kitura"))
+        jwt.claims.exp = Date()
+        XCTAssertEqual(jwt.validateClaims(leeway: 20), .success, "Validation failed")
+        jwt.claims.exp = nil
+        jwt.claims.iat = Date(timeIntervalSinceNow: 10)
+        XCTAssertEqual(jwt.validateClaims(leeway: 20), .success, "Validation failed")
+        jwt.claims.iat = nil
+        jwt.claims.nbf = Date(timeIntervalSinceNow: 10)
+        XCTAssertEqual(jwt.validateClaims(leeway: 20), .success, "Validation failed")
     }
 }
 


### PR DESCRIPTION
This PR adds a leeway parameter to the validateClaims function.
This allows a user to set a time interval during which the JWT will still be accepted even if the time claim is not valid. This can be used to take into account clock skew such as the example issue where the iat claim was being mistaken for being in the future.

Two tests have been added to check the validateClaims function working and that the leeway allows for slightly invalid dates being accepted.