### PR TITLE
Update podfile to 3.2.0

### DIFF
--- a/SwiftJWT.podspec
+++ b/SwiftJWT.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SwiftJWT"
-  s.version      = "3.1.1"
+  s.version      = "3.2.0"
   s.summary      = "An implementation of JSON Web Token using Swift."
   s.homepage     = "https://github.com/IBM-Swift/Swift-JWT"
   s.license      = { :type => "Apache License, Version 2.0" }


### PR DESCRIPTION
Updates the Swift-JWT.podspec file to point at Swift-JWT version 3.2. This is used for Cocoapods support.