### PR TITLE
Enabling pattern matching on JWTErrors

### DIFF
--- a/Sources/SwiftJWT/JWTError.swift
+++ b/Sources/SwiftJWT/JWTError.swift
@@ -52,4 +52,12 @@ public struct JWTError: Error, Equatable {
     public static func == (lhs: JWTError, rhs: JWTError) -> Bool {
         return lhs.internalError == rhs.internalError
     }
+
+    /// Function to enable pattern matching against generic Errors.
+    public static func ~= (lhs: JWTError, rhs: Error) -> Bool {
+        guard let rhs = rhs as? JWTError else {
+            return false
+        }
+        return lhs == rhs
+    }
 }


### PR DESCRIPTION
As is JWTErrors are can not be pattern matched with generic errors.  This keeps us from catching specific JWTErrors.
Currently we must:
```
do {
	let jwt = try JWT<MyClaims>(jwtString: token,  verifier: verifier)
} catch let error as JWTError {
	switch error {
	case .invalidJWTString:
		handleInvalidJWT()
	case .failedVerification:
		handleFailedVerification()
	}
}
```

With this change, it allows the following:
```
do {
	let jwt = try JWT<MyClaims>(jwtString: token,  verifier: verifier)
} catch JWTError.invalidJWTString {
	handleInvalidJWT()
} catch JWTError.failedVerification {
	handleFailedVerification()
}
```