### PR TITLE
Docs: Updated function call for decoding a JWT-String

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ if validationResult != .success {
 A JWT struct can be initialized from a JWT string.  If a JWTVerifier is provided it will be used to verify the signature before initialization
 
 ```swift
-let newJWT = try JWT<MyClaims>(jwtString: signedJWT, jwtVerifier: jwtVerifier)
+let newJWT = try JWT<MyClaims>(jwtString: signedJWT, verifier: jwtVerifier)
 ```
 
 ### JWTEncoder and JWTDecoder


### PR DESCRIPTION
In `JWT.swift`, the referred initializer is declared

```swift
public init(jwtString: String, verifier: JWTVerifier = .none ) throws {
```
Therefore the second argument name should not be` jwtVerifier`, but `verifier`