### PR TITLE
fix: Update @available for iOS, watchOS and tvOS

### DIFF
--- a/Sources/SwiftJWT/BlueECDSA.swift
+++ b/Sources/SwiftJWT/BlueECDSA.swift
@@ -19,7 +19,7 @@ import LoggerAPI
 import Foundation
 
 // Class for ECDSA signing using BlueECC
-@available(OSX 10.13, *)
+@available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
 class BlueECSigner: SignerAlgorithm {
     let name: String = "ECDSA"
     
@@ -58,7 +58,7 @@ class BlueECSigner: SignerAlgorithm {
 }
 
 // Class for ECDSA verifying using BlueECC
-@available(OSX 10.13, *)
+@available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
 class BlueECVerifier: VerifierAlgorithm {
     
     let name: String = "ECDSA"

--- a/Sources/SwiftJWT/BlueRSA.swift
+++ b/Sources/SwiftJWT/BlueRSA.swift
@@ -45,7 +45,7 @@ class BlueRSA: SignerAlgorithm, VerifierAlgorithm {
     }
     
     func sign(_ data: Data) throws -> Data {
-        guard #available(macOS 10.12, iOS 10.0, *) else {
+		guard #available(macOS 10.12, iOS 10.3, tvOS 12.0, watchOS 3.3, *) else {
             Log.error("macOS 10.12.0 (Sierra) or higher or iOS 10.0 or higher is required by CryptorRSA")
             throw JWTError.osVersionToLow
         }
@@ -76,7 +76,7 @@ class BlueRSA: SignerAlgorithm, VerifierAlgorithm {
     }
     
     func verify(signature: Data, for data: Data) -> Bool {
-        guard #available(macOS 10.12, iOS 10.0, *) else {
+		guard #available(macOS 10.12, iOS 10.3, tvOS 12.0, watchOS 3.3, *) else {
             return false
         }
         do {

--- a/Sources/SwiftJWT/BlueRSA.swift
+++ b/Sources/SwiftJWT/BlueRSA.swift
@@ -45,7 +45,7 @@ class BlueRSA: SignerAlgorithm, VerifierAlgorithm {
     }
     
     func sign(_ data: Data) throws -> Data {
-		guard #available(macOS 10.12, iOS 10.3, tvOS 12.0, watchOS 3.3, *) else {
+        guard #available(macOS 10.12, iOS 10.3, tvOS 12.0, watchOS 3.3, *) else {
             Log.error("macOS 10.12.0 (Sierra) or higher or iOS 10.0 or higher is required by CryptorRSA")
             throw JWTError.osVersionToLow
         }
@@ -76,7 +76,7 @@ class BlueRSA: SignerAlgorithm, VerifierAlgorithm {
     }
     
     func verify(signature: Data, for data: Data) -> Bool {
-		guard #available(macOS 10.12, iOS 10.3, tvOS 12.0, watchOS 3.3, *) else {
+        guard #available(macOS 10.12, iOS 10.3, tvOS 12.0, watchOS 3.3, *) else {
             return false
         }
         do {

--- a/Sources/SwiftJWT/JWTSigner.swift
+++ b/Sources/SwiftJWT/JWTSigner.swift
@@ -122,21 +122,21 @@ public struct JWTSigner {
     
     /// Initialize a JWTSigner using the ECDSA SHA256 algorithm and the provided privateKey.
     /// - Parameter privateKey: The UTF8 encoded PEM private key, with either a "BEGIN EC PRIVATE KEY" or "BEGIN PRIVATE KEY" header.
-    @available(OSX 10.13, *)
+	@available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
     public static func es256(privateKey: Data) -> JWTSigner {
         return JWTSigner(name: "ES256", signerAlgorithm: BlueECSigner(key: privateKey, curve: .prime256v1))
     }
     
     /// Initialize a JWTSigner using the ECDSA SHA384 algorithm and the provided privateKey.
     /// - Parameter privateKey: The UTF8 encoded PEM private key, with either a "BEGIN EC PRIVATE KEY" or "BEGIN PRIVATE KEY" header.
-    @available(OSX 10.13, *)
+    @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
     public static func es384(privateKey: Data) -> JWTSigner {
         return JWTSigner(name: "ES384", signerAlgorithm: BlueECSigner(key: privateKey, curve: .secp384r1))
     }
     
     /// Initialize a JWTSigner using the ECDSA SHA512 algorithm and the provided privateKey.
     /// - Parameter privateKey: The UTF8 encoded PEM private key, with either a "BEGIN EC PRIVATE KEY" or "BEGIN PRIVATE KEY" header.
-    @available(OSX 10.13, *)
+    @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
     public static func es512(privateKey: Data) -> JWTSigner {
         return JWTSigner(name: "ES512", signerAlgorithm: BlueECSigner(key: privateKey, curve: .secp521r1))
     }

--- a/Sources/SwiftJWT/JWTSigner.swift
+++ b/Sources/SwiftJWT/JWTSigner.swift
@@ -122,7 +122,7 @@ public struct JWTSigner {
     
     /// Initialize a JWTSigner using the ECDSA SHA256 algorithm and the provided privateKey.
     /// - Parameter privateKey: The UTF8 encoded PEM private key, with either a "BEGIN EC PRIVATE KEY" or "BEGIN PRIVATE KEY" header.
-	@available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
+    @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
     public static func es256(privateKey: Data) -> JWTSigner {
         return JWTSigner(name: "ES256", signerAlgorithm: BlueECSigner(key: privateKey, curve: .prime256v1))
     }

--- a/Sources/SwiftJWT/JWTVerifier.swift
+++ b/Sources/SwiftJWT/JWTVerifier.swift
@@ -128,21 +128,21 @@ public struct JWTVerifier {
     
     /// Initialize a JWTVerifier using the ECDSA SHA 256 algorithm and the provided public key.
     /// - Parameter publicKey: The UTF8 encoded PEM public key, with a "BEGIN PUBLIC KEY" header.
-    @available(OSX 10.13, *)
+    @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
     public static func es256(publicKey: Data) -> JWTVerifier {
         return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .prime256v1))
     }
     
     /// Initialize a JWTVerifier using the ECDSA SHA 384 algorithm and the provided public key.
     /// - Parameter publicKey: The UTF8 encoded PEM public key, with a "BEGIN PUBLIC KEY" header.
-    @available(OSX 10.13, *)
+    @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
     public static func es384(publicKey: Data) -> JWTVerifier {
         return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .secp384r1))
     }
     
     /// Initialize a JWTVerifier using the ECDSA SHA 512 algorithm and the provided public key.
     /// - Parameter publicKey: The UTF8 encoded PEM public key, with a "BEGIN PUBLIC KEY" header.
-    @available(OSX 10.13, *)
+    @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
     public static func es512(publicKey: Data) -> JWTVerifier {
         return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .secp521r1))
     }

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -186,7 +186,7 @@ class TestJWT: XCTestCase {
     }
     
     func testSignAndVerifyECDSA() {
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *) {
             do {
                 try signAndVerify(signer: .es256(privateKey: ecdsaPrivateKey), verifier: .es256(publicKey: ecdsaPublicKey))
             } catch {
@@ -231,7 +231,7 @@ class TestJWT: XCTestCase {
     }
     
     func testSignAndVerifyECDSA384() {
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *) {
             do {
                 try signAndVerify(signer: .es384(privateKey: ec384PrivateKey), verifier: .es384(publicKey: ec384PublicKey))
             } catch {
@@ -249,7 +249,7 @@ class TestJWT: XCTestCase {
     }
     
     func testSignAndVerifyRSAPSS512() {
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.13, iOS 11, *) {
             do {
                 try signAndVerify(signer: .ps512(privateKey: rsaPrivateKey), verifier: .ps512(publicKey: rsaPublicKey))
             } catch {
@@ -276,7 +276,7 @@ class TestJWT: XCTestCase {
     }
     
     func testSignAndVerifyECDSA512() {
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.13, iOS 11, tvOS 11.0, *) {
             do {
                 try signAndVerify(signer: .es512(privateKey: ec512PrivateKey), verifier: .es512(publicKey: ec512PublicKey))
             } catch {
@@ -554,7 +554,7 @@ class TestJWT: XCTestCase {
     
     // Test using a JWT generated from jwt.io using es256 with `ecdsaPrivateKey` for interoperability.
     func testJWTUsingECDSA() {
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.13, iOS 11, tvOS 11.0, *) {
             let ok = JWT<TestClaims>.verify(ecdsaEncodedTestClaimJWT, using: .es256(publicKey: ecdsaPublicKey))
             XCTAssertTrue(ok, "Verification failed")
             


### PR DESCRIPTION
This pull request updates the @available tag for iOS, watchOS and tvOS. This fixes errors #64 #65 and #66 and allows the project to be compiled on those operating systems. This was not an issue before because we recommended using Cocoapods which already had those requirements in place. 