### PR TITLE
ci: Enable Xcode11 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,10 @@ matrix:
     - os: osx
       osx_image: xcode10.2
       sudo: required
-# Pending Travis Xcode 11 image
-#    - os: osx
-#      osx_image: xcode11
-#      sudo: required
-#      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: osx
+      osx_image: xcode11
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/SwiftJWT/BlueRSA.swift
+++ b/Sources/SwiftJWT/BlueRSA.swift
@@ -53,7 +53,7 @@ class BlueRSA: SignerAlgorithm, VerifierAlgorithm {
         let keyDer: Data
         if let keyString = String(data: key, encoding: .utf8) {
             let strippedKey = String(keyString.filter { !" \n\t\r".contains($0) })
-            var pemComponents = strippedKey.components(separatedBy: "-----")
+            let pemComponents = strippedKey.components(separatedBy: "-----")
             guard pemComponents.count >= 5 else {
                 throw JWTError.missingPEMHeaders
             }
@@ -101,7 +101,7 @@ class BlueRSA: SignerAlgorithm, VerifierAlgorithm {
                 let keyDer: Data
                 if let keyString = String(data: key, encoding: .utf8) {
                     let strippedKey = String(keyString.filter { !" \n\t\r".contains($0) })
-                    var pemComponents = strippedKey.components(separatedBy: "-----")
+                    let pemComponents = strippedKey.components(separatedBy: "-----")
                     guard pemComponents.count >= 5 else {
                         return false
                     }


### PR DESCRIPTION
Travis recently published an `xcode11` macOS image.  This enables the macOS 5.1 CI testing.
Also resolve a compile warning.