### PR TITLE
Add asn1 signature encoding to signer and verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ The supported algorithms for signing and verifying JWTs are:
 
 Note: ECDSA and RSA-PSS algorithms require a minimum Swift version of 4.1.
 
+
+#### Using ASN1 encoding for ECDSA signature
+
+In some cases the ASN1 encoding for ECDSA signatures might be necessary. To use this, a `signatureType: ECSignatureType` parameter can be used for the `JWTSigner` and `JWTVerifier` like this:
+
+```swift
+let jwtSigner = JWTSigner.es512(privateKey: privateKey, signatureType: .asn1)
+let jwtVerifier = JWTVerifier.es512(publicKey: publicKey, signatureType: .asn1)
+```
+
+
 ### Validate claims
 
 The `validateClaims` function validates the standard `Date` claims of a JWT instance.

--- a/Sources/SwiftJWT/JWTSigner.swift
+++ b/Sources/SwiftJWT/JWTSigner.swift
@@ -123,22 +123,22 @@ public struct JWTSigner {
     /// Initialize a JWTSigner using the ECDSA SHA256 algorithm and the provided privateKey.
     /// - Parameter privateKey: The UTF8 encoded PEM private key, with either a "BEGIN EC PRIVATE KEY" or "BEGIN PRIVATE KEY" header.
     @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
-    public static func es256(privateKey: Data) -> JWTSigner {
-        return JWTSigner(name: "ES256", signerAlgorithm: BlueECSigner(key: privateKey, curve: .prime256v1))
+    public static func es256(privateKey: Data, signatureType: ECSignatureType = .rs) -> JWTSigner {
+        return JWTSigner(name: "ES256", signerAlgorithm: BlueECSigner(key: privateKey, curve: .prime256v1, signatureType: signatureType))
     }
     
     /// Initialize a JWTSigner using the ECDSA SHA384 algorithm and the provided privateKey.
     /// - Parameter privateKey: The UTF8 encoded PEM private key, with either a "BEGIN EC PRIVATE KEY" or "BEGIN PRIVATE KEY" header.
     @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
-    public static func es384(privateKey: Data) -> JWTSigner {
-        return JWTSigner(name: "ES384", signerAlgorithm: BlueECSigner(key: privateKey, curve: .secp384r1))
+    public static func es384(privateKey: Data, signatureType: ECSignatureType = .rs) -> JWTSigner {
+        return JWTSigner(name: "ES384", signerAlgorithm: BlueECSigner(key: privateKey, curve: .secp384r1, signatureType: signatureType))
     }
     
     /// Initialize a JWTSigner using the ECDSA SHA512 algorithm and the provided privateKey.
     /// - Parameter privateKey: The UTF8 encoded PEM private key, with either a "BEGIN EC PRIVATE KEY" or "BEGIN PRIVATE KEY" header.
     @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
-    public static func es512(privateKey: Data) -> JWTSigner {
-        return JWTSigner(name: "ES512", signerAlgorithm: BlueECSigner(key: privateKey, curve: .secp521r1))
+    public static func es512(privateKey: Data, signatureType: ECSignatureType = .rs) -> JWTSigner {
+        return JWTSigner(name: "ES512", signerAlgorithm: BlueECSigner(key: privateKey, curve: .secp521r1, signatureType: signatureType))
     }
     
     /// Initialize a JWTSigner that will not sign the JWT. This is equivelent to using the "none" alg header.

--- a/Sources/SwiftJWT/JWTVerifier.swift
+++ b/Sources/SwiftJWT/JWTVerifier.swift
@@ -129,22 +129,22 @@ public struct JWTVerifier {
     /// Initialize a JWTVerifier using the ECDSA SHA 256 algorithm and the provided public key.
     /// - Parameter publicKey: The UTF8 encoded PEM public key, with a "BEGIN PUBLIC KEY" header.
     @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
-    public static func es256(publicKey: Data) -> JWTVerifier {
-        return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .prime256v1))
+    public static func es256(publicKey: Data, signatureType: ECSignatureType = .rs) -> JWTVerifier {
+        return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .prime256v1, signatureType: signatureType))
     }
     
     /// Initialize a JWTVerifier using the ECDSA SHA 384 algorithm and the provided public key.
     /// - Parameter publicKey: The UTF8 encoded PEM public key, with a "BEGIN PUBLIC KEY" header.
     @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
-    public static func es384(publicKey: Data) -> JWTVerifier {
-        return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .secp384r1))
+    public static func es384(publicKey: Data, signatureType: ECSignatureType = .rs) -> JWTVerifier {
+        return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .secp384r1, signatureType: signatureType))
     }
     
     /// Initialize a JWTVerifier using the ECDSA SHA 512 algorithm and the provided public key.
     /// - Parameter publicKey: The UTF8 encoded PEM public key, with a "BEGIN PUBLIC KEY" header.
     @available(OSX 10.13, iOS 11, tvOS 11.0, watchOS 4.0, *)
-    public static func es512(publicKey: Data) -> JWTVerifier {
-        return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .secp521r1))
+    public static func es512(publicKey: Data, signatureType: ECSignatureType = .rs) -> JWTVerifier {
+        return JWTVerifier(verifierAlgorithm: BlueECVerifier(key: publicKey, curve: .secp521r1, signatureType: signatureType))
     }
     
     /// Initialize a JWTVerifier that will always return true when verifying the JWT. This is equivelent to using the "none" alg header.

--- a/Tests/SwiftJWTTests/TestJWT.swift
+++ b/Tests/SwiftJWTTests/TestJWT.swift
@@ -295,6 +295,16 @@ class TestJWT: XCTestCase {
         }
     }
     
+    func testSignAndVerifyECDSA512ASN1() {
+        if #available(OSX 10.13, iOS 11, tvOS 11.0, *) {
+            do {
+                try signAndVerify(signer: .es512(privateKey: ec512PrivateKey, signatureType: .asn1), verifier: .es512(publicKey: ec512PublicKey, signatureType: .asn1))
+            } catch {
+                XCTFail("testSignAndVerify failed: \(error)")
+            }
+        }
+    }
+    
     func signAndVerify(signer: JWTSigner, verifier: JWTVerifier) throws {
         var jwt = JWT(claims: TestClaims(name:"Kitura"))
         jwt.claims.name = "Kitura-JWT"


### PR DESCRIPTION
Unfortunately, we're using a library (for another language), which doesn't support concatenating `r` and `s` for the signature, so we needed a way to use a common encoding. Since the "original" encoding when used in iOS (or macOS) is ASN1, this data is already available inside the `ECSignature`.
This change isn't breaking, since without changing anything, the old encoding is used.

I know, this isn't quite correct for the JWS standard, but maybe there are other people running into this problem. What do you think about this option?