### PR TITLE
Add guard to handle index out of range exception

### DIFF
--- a/Sources/SwiftJWT/JWTDecoder.swift
+++ b/Sources/SwiftJWT/JWTDecoder.swift
@@ -75,7 +75,8 @@ public class JWTDecoder: BodyDecoder {
     public func decode<T : Decodable>(_ type: T.Type, fromString: String) throws -> T {
         // Seperate the JWT into the headers and claims.
         let components = fromString.components(separatedBy: ".")
-        guard let headerData = JWTDecoder.data(base64urlEncoded: components[0]),
+        guard components.count > 1,
+         let headerData = JWTDecoder.data(base64urlEncoded: components[0]),
             let claimsData = JWTDecoder.data(base64urlEncoded: components[1])
         else {
             throw JWTError.invalidJWTString


### PR DESCRIPTION
This pull request is intended to address issue #73  where JWTDecoder may crash with ‘index out of range error’ if a passed String does not fit into the correct JWT format. 

This PR adds a guard that checks the number of components separated by dots ( . ) inside the string.