### PR TITLE
Fix JWT signing issue

### DIFF
--- a/Sources/SwiftJWT/JWTSigner.swift
+++ b/Sources/SwiftJWT/JWTSigner.swift
@@ -61,7 +61,7 @@ public struct JWTSigner {
         self.signerAlgorithm = signerAlgorithm
     }
     
-    func sign(header: String, claims: String) throws -> String {
+    public func sign(header: String, claims: String) throws -> String {
         return try signerAlgorithm.sign(header: header, claims: claims)
     }
     


### PR DESCRIPTION
Made adjustment to JWTSigner to make it public for a call in iOS app...un-callable previously due to private restrictions...at least that is what I remember it was. 